### PR TITLE
add .verify() for one-stop verification of a buffer against a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ multihashing.digest(buf, 'sha1')
 var h = multihashing.createHash('sha1')
 h.update(buf)
 h.digest()
+
+// You can use `.verify()` to verify that a given multihash and a given blob match, as when receiving a blob from the network.
+var buf = new Buffer('beep boop')
+var otherbuf = new Buffer('oops')
+var hash = multihashing(buf, 'sha1')
+verify(hash, buf)       # true
+verify(hash, otherbuf)  # false
 ```
 
 ## Examples

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,12 @@ mh.createHash = function (func, length) {
   return mh.functions[func]()
 }
 
+mh.verify = function(multihash_input, buf) {
+    decoded = multihash.decode(multihash_input)
+    re_encoded = mh(buf, decoded.name, decoded.length)
+    return re_encoded.equals(multihash_input)
+}
+
 mh.functions = {
   0x11: gsha1,
   0x12: gsha2_256,

--- a/tests/test.js
+++ b/tests/test.js
@@ -34,3 +34,24 @@ test('sha2-512', function (t) {
 
   t.end()
 })
+
+test('verify-true', function (t) {
+    var buf = new Buffer('beep boop')
+
+    var mh = multihashing(buf, 'sha1')
+    t.true(multihashing.verify(mh, buf),
+           "verify() succeeds when the multihash matches the buffer")
+
+    t.end()
+})
+
+test('verify-false', function (t) {
+    var buf = new Buffer('beep boop')
+    var otherbuf = new Buffer('oops')
+
+    var mh = multihashing(buf, 'sha1')
+    t.false(multihashing.verify(mh, otherbuf),
+            "verify() fails when the multihash doesn't match the buffer")
+
+    t.end()
+})


### PR DESCRIPTION
Rationale: .verify() will likely be the most frequent operation, so it should be a shared utility function, not something endlessly reimplemented.

There are tests (they pass) and the library is lint clean. However, I didn't run a zuul test because I didn't have credentials.
