### PR TITLE
Use `sha.js` instead of full crypto in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "multihashes": "^0.2.0",
-    "webcrypto": "^0.1.0"
+    "sha.js": "^2.4.5",
+    "detect-node": "^2.0.3"
   },
   "devDependencies": {
     "aegir": "^2.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
-
+const isNode = require('detect-node')
 const multihash = require('multihashes')
-const crypto = require('webcrypto')
+const createHash = (isNode ? require('crypto').createHash : require('sha.js'))
 
 const mh = module.exports = Multihashing
 
@@ -43,13 +43,13 @@ mh.functions = {
 }
 
 function gsha1 () {
-  return crypto.createHash('sha1')
+  return createHash('sha1')
 }
 
 function gsha2_256 () {
-  return crypto.createHash('sha256')
+  return createHash('sha256')
 }
 
 function gsha2_512 () {
-  return crypto.createHash('sha512')
+  return createHash('sha512')
 }


### PR DESCRIPTION
Only use sha.js per suggestions from @dignifiedquire here https://github.com/ipfs/js-ipfs-api/issues/353

Not sure how much of an effect it will have on the distribution size
